### PR TITLE
fix: verify that `changedKeys` exists before checking of it includes items

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -78,7 +78,11 @@
     "local"
   ],
   "contributors": {
-    "developers": [],
+    "developers": [
+      {
+        "name": "omBratteng"
+      }
+    ],
     "translators": [
       {
         "name": "ChatGPT"

--- a/drivers/mill-sense/device.js
+++ b/drivers/mill-sense/device.js
@@ -211,7 +211,7 @@ class MillSense extends Device {
 
   async onSettings(oldSettings, newSettings, changedKeys) {
     this.log('onSettings', oldSettings, newSettings, changedKeys);
-    if (changedKeys.includes('username') && changedKeys.includes('password')) {
+    if (changedKeys && changedKeys.includes('username') && changedKeys.includes('password')) {
       this.homey.app.dDebug('Username and password changed');
       this.connectToMill();
     }

--- a/drivers/mill-silent-pro-compact/device.js
+++ b/drivers/mill-silent-pro-compact/device.js
@@ -206,7 +206,7 @@ class MillSilentProCompact extends Device {
 
   async onSettings(oldSettings, newSettings, changedKeys) {
     this.log('onSettings', oldSettings, newSettings, changedKeys);
-    if (changedKeys.includes('username') && changedKeys.includes('password')) {
+    if (changedKeys && changedKeys.includes('username') && changedKeys.includes('password')) {
       this.homey.app.dDebug('Username and password changed');
       this.homey.app.connectToMill();
     }

--- a/drivers/mill-v2/device.js
+++ b/drivers/mill-v2/device.js
@@ -213,7 +213,7 @@ class MillDeviceV2 extends Device {
     }
 
     async onSettings(oldSettings, newSettings, changedKeys) {
-        if (changedKeys.includes('username') && changedKeys.includes('password')) {
+        if (changedKeys && changedKeys.includes('username') && changedKeys.includes('password')) {
             this.homey.app.dDebug('Username and password changed');
             this.homey.app.connectToMill();
         }

--- a/drivers/mill/device.js
+++ b/drivers/mill/device.js
@@ -211,7 +211,7 @@ class MillDevice extends Device {
   }
 
   async onSettings(oldSettings, newSettings, changedKeys) {
-    if (changedKeys.includes('username') && changedKeys.includes('password')) {
+    if (changedKeys && changedKeys.includes('username') && changedKeys.includes('password')) {
       this.homey.app.dDebug('Username and password changed');
       this.homey.app.connectToMill();
     }


### PR DESCRIPTION
Threw in a check to verify that the changedKeys are not undefined before checking if it includes the items.